### PR TITLE
Switch to self-hosted Enketo, update slug, prevent manage.py migratio…

### DIFF
--- a/xlsform_app/templates/upload.html
+++ b/xlsform_app/templates/upload.html
@@ -55,7 +55,7 @@ $(document).ready(function() {
 			{% if itemsets_url %}
 			<a href="{{ itemsets_url }}" class="btn btn-success">Download external choices CSV</a>
 			{% endif %}
-			<a href="http://odk.enke.to/preview?form={{ xml_url }}" target="_blank" class="btn btn-success">Preview in Enketo</a>
+			<a href="https://enketo.getodk.org/preview?form={{ xml_url }}" target="_blank" class="btn btn-success">Preview in browser</a>
 		</div>
 		{% endif %}
 	{% endif %}
@@ -67,6 +67,6 @@ $(document).ready(function() {
 
 <div id="output">
 </div>
-<div class="version muted"><a target="_parent" href="https://github.com/getodk/xlsform-online/releases/tag/v2.1.0">v2.1.0</a></div>
+<div class="version muted"><a target="_parent" href="https://github.com/getodk/xlsform-online/releases/tag/v2.1.1">v2.1.1</a></div>
 </body>
 </html>

--- a/xlsform_app/views.py
+++ b/xlsform_app/views.py
@@ -1,7 +1,7 @@
 # Create your views here.
 from django.http import HttpResponse
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render
 from django import forms
 
 import tempfile


### PR DESCRIPTION
* Switch to self-hosted Enketo at enketo.getodk.org
* Update slug to getodk
* Prevent manage.py migration error caused by unused render_to_response