### PR TITLE
Lock to specific Django version to prevent surprises

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.11.2
+Django==3.0.8
 pyxform==1.4.0


### PR DESCRIPTION
3.0.8 is the version that works on production right now.