### PR TITLE
UploadFileForm: filter uploadable files to Excel spreadsheets

### DIFF
--- a/xlsform_app/views.py
+++ b/xlsform_app/views.py
@@ -18,7 +18,7 @@ from pyxform.utils import sheet_to_csv, has_external_choices
 DJANGO_TMP_HOME = os.environ['DJANGO_TMP_HOME']
 
 class UploadFileForm(forms.Form):
-    file = forms.FileField()
+    file = forms.FileField(attrs={ 'accept': '.xls, .xlsx' })
 
 
 def clean_name(name):


### PR DESCRIPTION
Untested.

This change should filter files shown in the native file picker so that only `.xls` and `.xlsx` files are visible.  This might be a usability improvement.