### PR TITLE
Add uuid prefix in index

### DIFF
--- a/xlsform_app/views.py
+++ b/xlsform_app/views.py
@@ -84,7 +84,7 @@ def index(request):
                 os.mkdir(DJANGO_TMP_HOME)
 
             #Make a randomly generated directory to prevent name collisions
-            temp_dir = tempfile.mkdtemp(prefix='', dir=DJANGO_TMP_HOME)
+            temp_dir = tempfile.mkdtemp(prefix=uuid.uuid4().hex, dir=DJANGO_TMP_HOME)
             xml_path = os.path.join(temp_dir, filename + '.xml')
             itemsets_url = None
 


### PR DESCRIPTION
I tried out staging after #74 was merged. However, the download link did not include a UUID. It turns out that `tempfile.mkdtemp()` is called in two endpoints, `json_workbook` and `index`. #74 updated `json_workbook`; this PR updates `index`. When I try out this change locally, I see that the download link is prefixed with a UUID, for example:

/downloads/**9bb16674f0754c77b811102a93fc78da**izbse2lg/all-widgets.xml