### PR TITLE
Persist shared Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ docker run -e DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY -v $DJANGO_TMP_HOME:/tmp_home
 
 # CORS
 
-If you want to call `api/xlsform` from another application, please set the `CORS_ALLOWED_ORIGIN` value to the origin of that application in [`settings.py`](./xlsform_prj/settings.py)
+If you want to call `api/xlsform` from another application, please set the `DJANGO_CORS_ALLOWED_ORIGIN` environemnt variable e.g. `https://www.example.com`.

--- a/xlsform_app/urls.py
+++ b/xlsform_app/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     url(r'^$', views.index),
     url(r'^downloads/(?P<path>.*)$', views.serve_file),
+    url(r'^api/xlsform$', views.api_xlsform),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/xlsform_app/views.py
+++ b/xlsform_app/views.py
@@ -108,7 +108,7 @@ def convert_xlsform(file, baseDownloadUrl, preview_target):
 
             if has_external_choices(json_survey):
                 # Create a csv for the external choices
-                itemsets_csv = os.path.join(os.path.split(xls_path)[0],
+                itemsets_csv = os.path.join(os.path.split(xml_path)[0],
                                             "itemsets.csv")
                 choices_exported = sheet_to_csv(xls_path, itemsets_csv,
                                                 "external_choices")

--- a/xlsform_prj/settings.py
+++ b/xlsform_prj/settings.py
@@ -160,4 +160,4 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # SECURITY WARNING: don't run with CORS_ALLOWED_ORIGIN = * in production!
-CORS_ALLOWED_ORIGIN = ''
+CORS_ALLOWED_ORIGIN = os.getenv('DJANGO_CORS_ALLOWED_ORIGIN', '')

--- a/xlsform_prj/settings.py
+++ b/xlsform_prj/settings.py
@@ -159,5 +159,5 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
-# SECURITY WARNING: don't run with ALLOWED_HOSTS = * in production!
-CORS_ALLOWED_ORIGIN = '*'
+# SECURITY WARNING: don't run with CORS_ALLOWED_ORIGIN = * in production!
+CORS_ALLOWED_ORIGIN = ''

--- a/xlsform_prj/settings.py
+++ b/xlsform_prj/settings.py
@@ -158,3 +158,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# SECURITY WARNING: don't run with ALLOWED_HOSTS = * in production!
+CORS_ALLOWED_ORIGIN = '*'


### PR DESCRIPTION
### Changes:

- Added a JSON API to convert XLSForm (rationale: consuming existing index view from cross origin is difficult due to csrf prevention, even if allow a host for cross-site request, we would need to first fetch the csrf-token).
- Extracted core functionality from `index()` function to `convert_xlsform()`, re-used in both existing index view and new API.
- Added ability to persist uploaded file in a separate directory. `DJANGO_PERSISTENT_HOME` environment environment tells where to save the file. 
- Added new `CORS_ALLOWED_ORIGIN` setting that allow cross origin requests from the given host.
- User can now upload XML file as well to preview the Form. XML files are just ODK-validated using `pyxform`

### Question:
- Should I add a checkbox "Allow ODK to use form to help improve the service" in the index view/template?