### PR TITLE
Fix Django deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==3.2.25
+Django==4.2.17
 pyxform@git+https://github.com/xlsform/pyxform@master
 gunicorn==22.0.0

--- a/xlsform_app/urls.py
+++ b/xlsform_app/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.index),
-    url(r'^downloads/(?P<path>.*)$', views.serve_file),
-    url(r'^api/xlsform$', views.api_xlsform),
+    re_path(r'^$', views.index),
+    re_path(r'^downloads/(?P<path>.*)$', views.serve_file),
+    re_path(r'^api/xlsform$', views.api_xlsform),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/xlsform_prj/urls.py
+++ b/xlsform_prj/urls.py
@@ -13,8 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
 urlpatterns = [
-    url(r'', include('xlsform_app.urls')),
+    re_path(r'', include('xlsform_app.urls')),
 ]


### PR DESCRIPTION
I'm upgrading to the latest Django LTS because the version we use is deprecated and now has a vuln.

I've tested a basic form and can confirm it converts to XML and I can download it. I've also tested a form with select_one_external that has external itemsents and can download the CSV. Form previews on both testing paths fail expectedly because we don't have previews to staging.enketo.getodk.org enabled.

@sadiqkhoja Can you verify that api_xlsform works as expected? Perhaps you can share a curl command we can use in the future?