### PR TITLE
Add workflow for publishing container images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish
+
+on: push
+
+env:
+    # Use docker.io for Docker Hub if empty
+    REGISTRY: ghcr.io
+    # github.repository as <account>/<repo>
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            # Login against a Docker registry
+            # https://github.com/docker/login-action
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            # Setup QEMU emulator to build multi-arch images
+            # https://github.com/docker/setup-qemu-action
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            # Configure Buildx for Docker build
+            # https://github.com/docker/setup-buildx-action
+            - name: Set up Buildx
+              uses: docker/setup-buildx-action@v3
+
+            # Build and push Docker image with Buildx
+            # https://github.com/docker/build-push-action
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-FROM python:3.12.5-alpine
-
-RUN apk --update add openjdk8-jre-base git
-
-WORKDIR /usr/src/app
-
+FROM python:3.12.5-alpine AS build
+RUN apk --update --no-cache add git
 COPY requirements.txt ./
-
 RUN pip install --no-cache-dir -r requirements.txt
 
+ 
+FROM python:3.12.5-alpine AS runtime
+WORKDIR /usr/src/app
+RUN apk --update --no-cache add openjdk8-jre-base
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/
 COPY . .
-
 EXPOSE 8000
-
 VOLUME ["/tmp_home", "/persistent_home"]
-
 ENV DJANGO_TMP_HOME="/tmp_home"
-
 ENV DJANGO_PERSISTENT_HOME="/persistent_home"
-
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "5", "--timeout", "600", "--max-requests", "25", "--max-requests-jitter", "5", "xlsform_prj.wsgi:application"]


### PR DESCRIPTION
Small PR to:
- Optimise the container image build using multi-stage (186MB --> 173MB)
- Add the same workflow used in [pyxform-http](https://github.com/getodk/pyxform-http/blob/master/.github/workflows/publish.yml) for publishing the xlsform-online containers to this repo.

I added this because I needed to run xlsform-online when testing web-forms locally 👍 